### PR TITLE
feat: add research_web tool using OpenAI web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ _Last verified against commit `7317103`._
 
 Canna Mailroom is an **email-native AI agent runtime**. It watches a Gmail inbox, treats each Gmail thread as a session, and replies in-thread using OpenAI Responses API context chaining.
 
-It can also use Google Workspace tools during replies:
+It can also use tools during replies:
+- research the public web (`research_web`, via OpenAI web search tool)
 - read/list files in Drive
 - create Google Docs
 - append to existing Docs

--- a/SYSTEM_PROMPT.md
+++ b/SYSTEM_PROMPT.md
@@ -4,6 +4,7 @@ Mission:
 - Handle email conversations professionally and clearly.
 - Maintain context per email thread.
 - Use Google Drive and Google Docs tools when useful.
+- Use `research_web` when up-to-date public-web context is needed.
 
 Rules:
 - Be concise, practical, and helpful.

--- a/app/ai_agent.py
+++ b/app/ai_agent.py
@@ -20,6 +20,18 @@ class EmailAgent:
         return [
             {
                 "type": "function",
+                "name": "research_web",
+                "description": "Research the public web and return a concise cited summary.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "type": "function",
                 "name": "list_drive_files",
                 "description": "List files in Google Drive folder",
                 "parameters": {
@@ -71,7 +83,20 @@ class EmailAgent:
             },
         ]
 
+    def _research_web(self, query: str) -> dict[str, Any]:
+        response = self.client.responses.create(
+            model=self.model,
+            tools=[{"type": "web_search"}],
+            input=(
+                "Research the user's query and return a concise summary with source links.\n\n"
+                f"Query: {query}"
+            ),
+        )
+        return {"query": query, "summary": response.output_text.strip()}
+
     def _run_tool(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        if name == "research_web":
+            return self._research_web(**args)
         if name == "list_drive_files":
             return self.tools.list_drive_files(**args)
         if name == "create_google_doc":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,12 +82,12 @@ flowchart LR
 ## Tooling boundaries
 
 Current model-callable tools (hardcoded in `EmailAgent._tool_specs`):
+- `research_web` (implemented via nested OpenAI Responses API call with `web_search`)
 - `list_drive_files`
 - `create_google_doc`
 - `append_google_doc`
 - `read_google_doc`
 
-No web search tool is exposed.
 No direct Gmail tool is exposed to the model (Gmail handling is app-owned worker logic).
 
 ## Non-goals in current implementation


### PR DESCRIPTION
## Summary
- add model-callable `research_web` tool
- implement web research via OpenAI Responses API `web_search` tool
- update system prompt and docs to reflect web research capability

## Why
Enable the email agent to perform fresh web research before answering when needed.

## Validation
- python -m compileall app scripts
